### PR TITLE
rf: replace xrange with range

### DIFF
--- a/src/dcmstack/dcmmeta.py
+++ b/src/dcmstack/dcmmeta.py
@@ -2,7 +2,7 @@
 DcmMeta header extension and NiftiWrapper for working with extended Niftis.
 """
 from __future__ import print_function
-
+from builtins import range
 import sys
 import json, warnings
 from copy import deepcopy
@@ -907,7 +907,7 @@ class DcmMetaExtension(Nifti1Extension):
 
             if len(subset_vals) < dest_mult:
                 full_vals = []
-                for val_idx in xrange(dest_mult / len(subset_vals)):
+                for val_idx in range(dest_mult / len(subset_vals)):
                     full_vals += deepcopy(subset_vals)
                 subset_vals = full_vals
             if len(subset_vals) == 1:
@@ -936,7 +936,7 @@ class DcmMetaExtension(Nifti1Extension):
             else:
                 result = []
                 slices_per_vec = n_slices * shape[3]
-                for vec_idx in xrange(shape[4]):
+                for vec_idx in range(shape[4]):
                     start_idx = (vec_idx * slices_per_vec) + (idx * n_slices)
                     end_idx = start_idx + n_slices
                     result.extend(src_dict[key][start_idx:end_idx])
@@ -1121,7 +1121,7 @@ class DcmMetaExtension(Nifti1Extension):
             intlv = []
             loc_start = 0
             oth_start = 0
-            for vol_idx in xrange(n_vols):
+            for vol_idx in range(n_vols):
                 intlv += local_vals[loc_start:loc_start + n_slices]
                 intlv += other_vals[oth_start:oth_start + other_n_slices]
                 loc_start += n_slices
@@ -1171,7 +1171,7 @@ class DcmMetaExtension(Nifti1Extension):
                 intlv = []
                 loc_start = 0
                 oth_start = 0
-                for vec_idx in xrange(shape[4]):
+                for vec_idx in range(shape[4]):
                     intlv += local_vals[loc_start:loc_start+slices_per_vec]
                     intlv += other_vals[oth_start:oth_start+oth_slc_per_vec]
                     loc_start += slices_per_vec
@@ -1447,7 +1447,7 @@ class NiftiWrapper(object):
 
         split_hdr = header.copy()
         slices = [slice(None)] * len(shape)
-        for idx in xrange(shape[dim]):
+        for idx in range(shape[dim]):
             #Grab the split data, get rid of trailing singular dimensions
             if dim >= 3 and dim == len(shape) - 1:
                 slices[dim] = idx
@@ -1623,7 +1623,7 @@ class NiftiWrapper(object):
 
         #Pull out the three axes vectors for validation of other input affines
         axes = []
-        for axis_idx in xrange(3):
+        for axis_idx in range(3):
             axis_vec = affine[:3, axis_idx]
             if axis_idx == dim:
                 axis_vec = axis_vec.copy()
@@ -1731,12 +1731,12 @@ class NiftiWrapper(object):
                     hdr_info['sform_code'] = None
                 in_dim_info = list(input_hdr.get_dim_info())
                 if in_dim_info != hdr_info['dim_info']:
-                    for idx in xrange(3):
+                    for idx in range(3):
                         if in_dim_info[idx] != hdr_info['dim_info'][idx]:
                             hdr_info['dim_info'][idx] = None
                 in_xyzt_units = list(input_hdr.get_xyzt_units())
                 if in_xyzt_units != hdr_info['xyzt_units']:
-                    for idx in xrange(2):
+                    for idx in range(2):
                         if in_xyzt_units[idx] != hdr_info['xyzt_units'][idx]:
                             hdr_info['xyzt_units'][idx] = None
 

--- a/src/dcmstack/dcmstack.py
+++ b/src/dcmstack/dcmstack.py
@@ -2,6 +2,7 @@
 Stack DICOM datasets into volumes. The contents of this module are imported
 into the package namespace.
 """
+from builtins import range
 import warnings, re, dicom
 from copy import deepcopy
 import nibabel as nb
@@ -609,11 +610,11 @@ class DicomStack(object):
                            key=lambda x: x[1][-1])
 
         #Do a thorough check for correctness
-        for vec_idx in xrange(num_vec_comps):
+        for vec_idx in range(num_vec_comps):
             file_idx = vec_idx*num_time_points*files_per_vol
             curr_vec_val = self._files_info[file_idx][1][0]
-            for time_idx in xrange(num_time_points):
-                for slice_idx in xrange(files_per_vol):
+            for time_idx in range(num_time_points):
+                for slice_idx in range(files_per_vol):
                     file_idx = (vec_idx*num_time_points*files_per_vol +
                                 time_idx*files_per_vol + slice_idx)
                     file_info = self._files_info[file_idx]
@@ -662,7 +663,7 @@ class DicomStack(object):
         #If more than one file per volume, check that slice spacing is equal
         if files_per_vol > 1:
             spacings = []
-            for idx in xrange(files_per_vol - 1):
+            for idx in range(files_per_vol - 1):
                 spacings.append(slice_positions[idx+1] - slice_positions[idx])
             spacings = np.array(spacings)
             avg_spacing = np.mean(spacings)
@@ -702,7 +703,7 @@ class DicomStack(object):
             #Try out each possible sort order
             for time_order in possible_orders:
                 #Update sorting tuples
-                for idx in xrange(len(self._files_info)):
+                for idx in range(len(self._files_info)):
                     nii_wrp, curr_tuple = self._files_info[idx]
                     self._files_info[idx] = (nii_wrp,
                                              (curr_tuple[0],
@@ -882,11 +883,11 @@ class DicomStack(object):
             #This will keep the slice times and meta data order correct
             if files_per_vol > 1 and flips[slice_dim] == -1:
                 self._shape_dirty = True
-                for vol_idx in xrange(n_vols):
+                for vol_idx in range(n_vols):
                     start = vol_idx * files_per_vol
                     stop = start + files_per_vol
                     self._files_info[start:stop] = [self._files_info[idx]
-                                                    for idx in xrange(stop - 1,
+                                                    for idx in range(stop - 1,
                                                                       start - 1,
                                                                       -1)
                                                    ]
@@ -926,7 +927,7 @@ class DicomStack(object):
 
             #If there is more than one volume, check if times are consistent
             is_consistent = True
-            for vol_idx in xrange(1, n_vols):
+            for vol_idx in range(1, n_vols):
                 start_slice = vol_idx * n_slices
                 end_slice = start_slice + n_slices
                 slices_info = self._files_info[start_slice:end_slice]
@@ -952,7 +953,7 @@ class DicomStack(object):
             #Build meta data for each volume if needed
             vol_meta = []
             if files_per_vol > 1:
-                for vol_idx in xrange(n_vols):
+                for vol_idx in range(n_vols):
                     start_slice = vol_idx * n_slices
                     end_slice = start_slice + n_slices
                     exts = [file_info[0].meta_ext
@@ -967,7 +968,7 @@ class DicomStack(object):
             if len(data.shape) == 5:
                 if data.shape[3] != 1:
                     vec_meta = []
-                    for vec_idx in xrange(data.shape[4]):
+                    for vec_idx in range(data.shape[4]):
                         start_idx = vec_idx * data.shape[3]
                         end_idx = start_idx + data.shape[3]
                         meta = DcmMetaExtension.from_sequence(\

--- a/src/dcmstack/extract.py
+++ b/src/dcmstack/extract.py
@@ -6,6 +6,7 @@ from collections import namedtuple, defaultdict
 import dicom
 from dicom.datadict import keyword_for_tag
 from nibabel.nicom import csareader
+import sys
 from .dcmstack import DicomStack
 try:
     from collections import OrderedDict

--- a/test/test_dcmmeta.py
+++ b/test/test_dcmmeta.py
@@ -1,6 +1,7 @@
 """
 Tests for dcmstack.dcmmeta
 """
+from builtins import range
 import sys
 from os import path
 from glob import glob
@@ -341,17 +342,17 @@ class TestSimplify(object):
         glob_slc = self.ext.get_class_dict(('global', 'slices'))
         glob_slc['Test1'] = [0] * (3 * 5 * 7)
         glob_slc['Test2'] = []
-        for idx in xrange(7):
+        for idx in range(7):
             glob_slc['Test2'] += [idx] * (3 * 5)
         glob_slc['Test3'] = []
-        for idx in xrange(5 * 7):
+        for idx in range(5 * 7):
             glob_slc['Test3'] += [idx] * (3)
         glob_slc['Test4'] = []
-        for idx in xrange(7):
-            glob_slc['Test4'] += [idx2 for idx2 in xrange(3*5)]
+        for idx in range(7):
+            glob_slc['Test4'] += [idx2 for idx2 in range(3*5)]
         glob_slc['Test5'] = []
-        for idx in xrange(7 * 5):
-            glob_slc['Test5'] += [idx2 for idx2 in xrange(3)]
+        for idx in range(7 * 5):
+            glob_slc['Test5'] += [idx2 for idx2 in range(3)]
         self.ext.check_valid()
 
         eq_(self.ext._simplify('Test1'), True)
@@ -373,11 +374,11 @@ class TestSimplify(object):
         vec_slc = self.ext.get_class_dict(('vector', 'slices'))
         vec_slc['Test1'] = [0] * (3 * 5)
         vec_slc['Test2'] = []
-        for time_idx in xrange(5):
+        for time_idx in range(5):
             vec_slc['Test2'] += [time_idx] * 3
         vec_slc['Test3'] = []
-        for time_idx in xrange(5):
-            for slc_idx in xrange(3):
+        for time_idx in range(5):
+            for slc_idx in range(3):
                 vec_slc['Test3'] += [slc_idx]
         self.ext.check_valid()
 
@@ -402,7 +403,7 @@ class TestSimplify(object):
         time_smp = self.ext.get_class_dict(('time', 'samples'))
         time_smp['Test1'] = [0] * (5 * 7)
         time_smp['Test2'] = []
-        for vec_idx in xrange(7):
+        for vec_idx in range(7):
             time_smp['Test2'] += [vec_idx] * 5
         self.ext.check_valid()
 
@@ -449,7 +450,7 @@ class TestGetSubset(object):
             self.ext.get_class_dict(classes)[key] = range(mult)
 
     def test_slice_subset(self):
-        for slc_idx in xrange(self.ext.n_slices):
+        for slc_idx in range(self.ext.n_slices):
             sub = self.ext.get_subset(2, slc_idx)
             sub.check_valid()
 
@@ -473,8 +474,8 @@ class TestGetSubset(object):
 
     def test_slice_subset_simplify(self):
         vals = []
-        for time_idx in xrange(5):
-            for slice_idx in xrange(3):
+        for time_idx in range(5):
+            for slice_idx in range(3):
                 if slice_idx == 1:
                     vals.append(1)
                 else:
@@ -482,9 +483,9 @@ class TestGetSubset(object):
         self.ext.get_class_dict(('vector', 'slices'))['vec_slc_to_const'] = vals
 
         vals = []
-        for vector_idx in xrange(7):
-            for time_idx in xrange(5):
-                for slice_idx in xrange(3):
+        for vector_idx in range(7):
+            for time_idx in range(5):
+                for slice_idx in range(3):
                     if slice_idx == 1:
                         vals.append(1)
                     else:
@@ -501,7 +502,7 @@ class TestGetSubset(object):
             (1, ('global', 'const')))
 
     def test_time_sample_subset(self):
-        for time_idx in xrange(5):
+        for time_idx in range(5):
             sub = self.ext.get_subset(3, time_idx)
             sub.check_valid()
             for classes in self.ext.get_valid_classes():
@@ -532,7 +533,7 @@ class TestGetSubset(object):
                            )
                     elif classes[1] == 'slices':
                         vals = []
-                        for vec_idx in xrange(7):
+                        for vec_idx in range(7):
                             start = (vec_idx * (3 * 5)) + (time_idx * 3)
                             end = start + 3
                             vals += range(start, end)
@@ -542,13 +543,13 @@ class TestGetSubset(object):
     def test_time_sample_subset_simplify(self):
         #Test for simplification of time samples that become constant
         vals = []
-        for vector_idx in xrange(7):
-            for time_idx in xrange(5):
+        for vector_idx in range(7):
+            for time_idx in range(5):
                 vals.append(time_idx)
         self.ext.get_class_dict(('time', 'samples'))['time_smp_to_const'] = \
             vals
 
-        for time_idx in xrange(5):
+        for time_idx in range(5):
             sub = self.ext.get_subset(3, time_idx)
             sub.check_valid()
             eq_(sub.get_values_and_class('time_smp_to_const'),
@@ -556,8 +557,8 @@ class TestGetSubset(object):
 
         #Test for simplification of vector slices that become constant
         vals = []
-        for time_idx in xrange(5):
-            for slice_idx in xrange(3):
+        for time_idx in range(5):
+            for slice_idx in range(3):
                 if time_idx == 1:
                     vals.append(1)
                 else:
@@ -567,9 +568,9 @@ class TestGetSubset(object):
 
         #Test simplification of global slices that become constant
         vals = []
-        for vector_idx in xrange(7):
-            for time_idx in xrange(5):
-                for slice_idx in xrange(3):
+        for vector_idx in range(7):
+            for time_idx in range(5):
+                for slice_idx in range(3):
                     if time_idx == 1:
                         vals.append(1)
                     else:
@@ -587,9 +588,9 @@ class TestGetSubset(object):
         #Test simplification of global slices that become vector slices or
         #samples
         vals = []
-        for vector_idx in xrange(7):
-            for time_idx in xrange(5):
-                for slice_idx in xrange(3):
+        for vector_idx in range(7):
+            for time_idx in range(5):
+                for slice_idx in range(3):
                     if time_idx == 1:
                         vals.append(slice_idx)
                     else:
@@ -597,7 +598,7 @@ class TestGetSubset(object):
         self.ext.get_class_dict(('global', 'slices'))['glb_slc_to_vec'] = \
             vals
 
-        for time_idx in xrange(5):
+        for time_idx in range(5):
             sub = self.ext.get_subset(3, time_idx)
             sub.check_valid()
             if time_idx == 1:
@@ -608,7 +609,7 @@ class TestGetSubset(object):
                     (range(7), ('vector', 'samples')))
 
     def test_vector_sample_subset(self):
-        for vector_idx in xrange(7):
+        for vector_idx in range(7):
             sub = self.ext.get_subset(4, vector_idx)
             sub.check_valid()
             for classes in self.ext.get_valid_classes():
@@ -648,8 +649,8 @@ class TestGetSubset(object):
 
         #Test for simplification of time samples that become constant
         vals = []
-        for vector_idx in xrange(7):
-            for time_idx in xrange(5):
+        for vector_idx in range(7):
+            for time_idx in range(5):
                 if vector_idx == 1:
                     vals.append(1)
                 else:
@@ -663,9 +664,9 @@ class TestGetSubset(object):
         #Test for simplification of global slices that become constant, time
         #samples, or time slices
         vals = []
-        for vector_idx in xrange(7):
-            for time_idx in xrange(5):
-                for slice_idx in xrange(3):
+        for vector_idx in range(7):
+            for time_idx in range(5):
+                for slice_idx in range(3):
                     if vector_idx == 1:
                         vals.append(1)
                     elif vector_idx == 2:
@@ -675,7 +676,7 @@ class TestGetSubset(object):
         self.ext.get_class_dict(('global', 'slices'))['glb_slc'] = \
             vals
 
-        for vector_idx in xrange(7):
+        for vector_idx in range(7):
             sub = self.ext.get_subset(4, vector_idx)
             sub.check_valid()
             if vector_idx == 1:
@@ -738,13 +739,13 @@ class TestChangeClass(object):
 
     def test_change_vector_samples(self):
         vals = []
-        for vector_idx in xrange(7):
+        for vector_idx in range(7):
             vals += [vector_idx] * 15
         eq_(self.ext._get_changed_class('vector_samples_test',
                                         ('global', 'slices')),
             vals)
         vals = []
-        for vector_idx in xrange(7):
+        for vector_idx in range(7):
             vals += [vector_idx] * 5
         eq_(self.ext._get_changed_class('vector_samples_test',
                                         ('time', 'samples')),
@@ -752,7 +753,7 @@ class TestChangeClass(object):
 
     def test_change_time_samples(self):
         vals = []
-        for time_idx in xrange(5 * 7):
+        for time_idx in range(5 * 7):
             vals += [time_idx] * 3
         eq_(self.ext._get_changed_class('time_samples_test',
                                         ('global', 'slices')),
@@ -760,13 +761,13 @@ class TestChangeClass(object):
 
     def test_time_slices(self):
         vals = []
-        for time_idx in xrange(5 * 7):
+        for time_idx in range(5 * 7):
             vals += range(3)
         eq_(self.ext._get_changed_class('time_slices_test',
                                         ('global', 'slices')),
             vals)
         vals = []
-        for time_idx in xrange(5):
+        for time_idx in range(5):
             vals += range(3)
         eq_(self.ext._get_changed_class('time_slices_test',
                                         ('vector', 'slices')),
@@ -774,7 +775,7 @@ class TestChangeClass(object):
 
     def test_vector_slices(self):
         vals = []
-        for vector_idx in xrange(7):
+        for vector_idx in range(7):
             vals += range(15)
         eq_(self.ext._get_changed_class('vector_slices_test',
                                         ('global', 'slices')),
@@ -1017,9 +1018,9 @@ class TestGetMeta(object):
     def test_get_global_slices(self):
         eq_(self.nw.get_meta('global_slices_test'), None)
         eq_(self.nw.get_meta('global_slices_test', None, 0), 0)
-        for vector_idx in xrange(9):
-            for time_idx in xrange(7):
-                for slice_idx in xrange(5):
+        for vector_idx in range(9):
+            for time_idx in range(7):
+                for slice_idx in range(5):
                     idx = (0, 0, slice_idx, time_idx, vector_idx)
                     eq_(self.nw.get_meta('global_slices_test', idx),
                         slice_idx + (time_idx * 5) + (vector_idx * 7 * 5)
@@ -1028,9 +1029,9 @@ class TestGetMeta(object):
     def test_get_vector_slices(self):
         eq_(self.nw.get_meta('vector_slices_test'), None)
         eq_(self.nw.get_meta('vector_slices_test', None, 0), 0)
-        for vector_idx in xrange(9):
-            for time_idx in xrange(7):
-                for slice_idx in xrange(5):
+        for vector_idx in range(9):
+            for time_idx in range(7):
+                for slice_idx in range(5):
                     idx = (0, 0, slice_idx, time_idx, vector_idx)
                     eq_(self.nw.get_meta('vector_slices_test', idx),
                         slice_idx + (time_idx * 5)
@@ -1039,9 +1040,9 @@ class TestGetMeta(object):
     def test_get_time_slices(self):
         eq_(self.nw.get_meta('time_slices_test'), None)
         eq_(self.nw.get_meta('time_slices_test', None, 0), 0)
-        for vector_idx in xrange(9):
-            for time_idx in xrange(7):
-                for slice_idx in xrange(5):
+        for vector_idx in range(9):
+            for time_idx in range(7):
+                for slice_idx in range(5):
                     idx = (0, 0, slice_idx, time_idx, vector_idx)
                     eq_(self.nw.get_meta('time_slices_test', idx),
                         slice_idx
@@ -1050,9 +1051,9 @@ class TestGetMeta(object):
     def test_get_vector_samples(self):
         eq_(self.nw.get_meta('vector_samples_test'), None)
         eq_(self.nw.get_meta('vector_samples_test', None, 0), 0)
-        for vector_idx in xrange(9):
-            for time_idx in xrange(7):
-                for slice_idx in xrange(5):
+        for vector_idx in range(9):
+            for time_idx in range(7):
+                for slice_idx in range(5):
                     idx = (0, 0, slice_idx, time_idx, vector_idx)
                     eq_(self.nw.get_meta('vector_samples_test', idx),
                         vector_idx
@@ -1061,9 +1062,9 @@ class TestGetMeta(object):
     def get_time_samples(self):
         eq_(self.nw.get_meta('time_samples_test'), None)
         eq_(self.nw.get_meta('time_samples_test', None, 0), 0)
-        for vector_idx in xrange(9):
-            for time_idx in xrange(7):
-                for slice_idx in xrange(5):
+        for vector_idx in range(9):
+            for time_idx in range(7):
+                for slice_idx in range(5):
                     idx = (0, 0, slice_idx, time_idx, vector_idx)
                     eq_(self.nw.get_meta('time_samples_test', idx),
                         time_idx + (vector_idx * 7)
@@ -1152,7 +1153,7 @@ def test_from_dicom():
 
 def test_from_2d_slice_to_3d():
     slice_nws = []
-    for idx in xrange(3):
+    for idx in range(3):
         arr = np.arange(idx * (4 * 4), (idx + 1) * (4 * 4)).reshape(4, 4, 1)
         aff = np.diag((1.1, 1.1, 1.1, 1.0))
         aff[:3, 3] += [0.0, 0.0, idx * 0.5]
@@ -1180,14 +1181,14 @@ def test_from_2d_slice_to_3d():
     eq_(merged_hdr.get_dim_info(), (0, 1, 2))
     eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))
     merged_data = merged.nii_img.get_data()
-    for idx in xrange(3):
+    for idx in range(3):
         ok_(np.all(merged_data[:, :, idx] ==
                    np.arange(idx * (4 * 4), (idx + 1) * (4 * 4)).reshape(4, 4))
            )
 
 def test_from_3d_time_to_4d():
     time_nws = []
-    for idx in xrange(3):
+    for idx in range(3):
         arr = np.arange(idx * (4 * 4 * 4),
                         (idx + 1) * (4 * 4 * 4)
                        ).reshape(4, 4, 4)
@@ -1225,7 +1226,7 @@ def test_from_3d_time_to_4d():
     eq_(merged_hdr.get_dim_info(), (0, 1, 2))
     eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))
     merged_data = merged.nii_img.get_data()
-    for idx in xrange(3):
+    for idx in range(3):
         ok_(np.all(merged_data[:, :, :, idx] ==
                    np.arange(idx * (4 * 4 * 4),
                              (idx + 1) * (4 * 4 * 4)).reshape(4, 4, 4))
@@ -1233,7 +1234,7 @@ def test_from_3d_time_to_4d():
 
 def test_from_3d_vector_to_4d():
     vector_nws = []
-    for idx in xrange(3):
+    for idx in range(3):
         arr = np.arange(idx * (4 * 4 * 4),
                         (idx + 1) * (4 * 4 * 4)
                        ).reshape(4, 4, 4)
@@ -1271,7 +1272,7 @@ def test_from_3d_vector_to_4d():
     eq_(merged_hdr.get_dim_info(), (0, 1, 2))
     eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))
     merged_data = merged.nii_img.get_data()
-    for idx in xrange(3):
+    for idx in range(3):
         ok_(np.all(merged_data[:, :, :, 0, idx] ==
                    np.arange(idx * (4 * 4 * 4),
                              (idx + 1) * (4 * 4 * 4)).reshape(4, 4, 4))
@@ -1281,7 +1282,7 @@ def test_merge_inconsistent_hdr():
     #Test that inconsistent header data does not make it into the merged
     #result
     time_nws = []
-    for idx in xrange(3):
+    for idx in range(3):
         arr = np.arange(idx * (4 * 4 * 4),
                         (idx + 1) * (4 * 4 * 4)
                        ).reshape(4, 4, 4)
@@ -1304,7 +1305,7 @@ def test_merge_inconsistent_hdr():
 def test_merge_with_slc_and_without():
     #Test merging two data sets where one has per slice meta and other does not
     input_nws = []
-    for idx in xrange(3):
+    for idx in range(3):
         arr = np.arange(idx * (4 * 4 * 4),
                         (idx + 1) * (4 * 4 * 4)
                        ).reshape(4, 4, 4)


### PR DESCRIPTION
covers some of the incompatibilities..

TODO (that I've seen)
* `DcmMetaExtension` differences between py2/3
  * `from_sequence` method list error
  * missing `CSA` fields in PY3 meta for Siemens data